### PR TITLE
Remove random `color` property in box-shadow

### DIFF
--- a/lesshat.less
+++ b/lesshat.less
@@ -830,8 +830,6 @@
       .result(@arguments, @mozSignal, @moz, @mozLocal);
       // --
       .result(@arguments, @w3cSignal, @w3c, @w3cLocal);
-
-      color: @arguments;
   }
 
    //   element{ .box-shadow(0 1px 10px rgba(20,20,20,0.5), 0 1px 10px rgba(20,20,20,0.5)); }


### PR DESCRIPTION
This appears to be an oversight.
