### PR TITLE
Add output for `column-break-*` declarations.

### DIFF
--- a/lesshat.less
+++ b/lesshat.less
@@ -36,6 +36,9 @@
     //    .column-gap
     //    .column-rule
     //    .column-width
+    //    .column-break-inside
+    //    .column-break-before
+    //    .column-break-after
 //    .font-face
 //    .gradient
 //    .opacity
@@ -1007,6 +1010,93 @@
   }
 
     //  element{ .column-width(100px); }
+
+
+//  .column-break-inside
+
+  .column-break-inside(@arguments:auto){
+
+      //  Local config for disabling properties
+
+      @w3cLocal: true; // Unprefixed W3C syntax
+      @webkitLocal: true; // Chrome 7+, Safari 5+, iOS5, Android
+      @mozLocal: true; //  Firefox 4+
+
+      .result (@arguments, @signal, @boolean, @localBoolean) when (@boolean = true) and (@localBoolean = true) {
+        .inception (@signal, @arguments) when (@signal = 1) { -webkit-column-break-inside: @arguments;}
+        .inception (@signal, @arguments) when (@signal = 2) { -moz-column-break-inside: @arguments;}
+        .inception (@signal, @arguments) when (@signal = 5) { column-break-inside: @arguments;}
+        .inception (@signal, @arguments) when (@signal > 5),(@signal < 1) { error: "Signal is out of range"; }
+        .inception(@signal, @arguments);
+      }
+      .result (@arguments, @signal, @boolean, @localBoolean) when not (@boolean = true), not (@localBoolean = true) { }
+
+      .result(@arguments, @webkitSignal, @webkit, @webkitLocal);
+      // --  this comment must be here because of LESS bug
+      .result(@arguments, @mozSignal, @moz, @mozLocal);
+      // --
+      .result(@arguments, @w3cSignal, @w3c, @w3cLocal);
+  }
+
+    //  element{ .column-break-inside(avoid); }
+
+
+//  .column-break-before
+
+  .column-break-before(@arguments:auto){
+
+      //  Local config for disabling properties
+
+      @w3cLocal: true; // Unprefixed W3C syntax
+      @webkitLocal: true; // Chrome 7+, Safari 5+, iOS5, Android
+      @mozLocal: true; //  Firefox 4+
+
+      .result (@arguments, @signal, @boolean, @localBoolean) when (@boolean = true) and (@localBoolean = true) {
+        .inception (@signal, @arguments) when (@signal = 1) { -webkit-column-break-before: @arguments;}
+        .inception (@signal, @arguments) when (@signal = 2) { -moz-column-break-before: @arguments;}
+        .inception (@signal, @arguments) when (@signal = 5) { column-break-before: @arguments;}
+        .inception (@signal, @arguments) when (@signal > 5),(@signal < 1) { error: "Signal is out of range"; }
+        .inception(@signal, @arguments);
+      }
+      .result (@arguments, @signal, @boolean, @localBoolean) when not (@boolean = true), not (@localBoolean = true) { }
+
+      .result(@arguments, @webkitSignal, @webkit, @webkitLocal);
+      // --  this comment must be here because of LESS bug
+      .result(@arguments, @mozSignal, @moz, @mozLocal);
+      // --
+      .result(@arguments, @w3cSignal, @w3c, @w3cLocal);
+  }
+
+    //  element{ .column-break-before(avoid); }
+
+
+//  .column-break-after
+
+  .column-break-after(@arguments:auto){
+
+      //  Local config for disabling properties
+
+      @w3cLocal: true; // Unprefixed W3C syntax
+      @webkitLocal: true; // Chrome 7+, Safari 5+, iOS5, Android
+      @mozLocal: true; //  Firefox 4+
+
+      .result (@arguments, @signal, @boolean, @localBoolean) when (@boolean = true) and (@localBoolean = true) {
+        .inception (@signal, @arguments) when (@signal = 1) { -webkit-column-break-after: @arguments;}
+        .inception (@signal, @arguments) when (@signal = 2) { -moz-column-break-after: @arguments;}
+        .inception (@signal, @arguments) when (@signal = 5) { column-break-after: @arguments;}
+        .inception (@signal, @arguments) when (@signal > 5),(@signal < 1) { error: "Signal is out of range"; }
+        .inception(@signal, @arguments);
+      }
+      .result (@arguments, @signal, @boolean, @localBoolean) when not (@boolean = true), not (@localBoolean = true) { }
+
+      .result(@arguments, @webkitSignal, @webkit, @webkitLocal);
+      // --  this comment must be here because of LESS bug
+      .result(@arguments, @mozSignal, @moz, @mozLocal);
+      // --
+      .result(@arguments, @w3cSignal, @w3c, @w3cLocal);
+  }
+
+    //  element{ .column-break-after(avoid); }
 
 
 //  .font-face


### PR DESCRIPTION
This provides 3 rules for controlling break options in CSS columns as outlined in these documents:
- http://www.w3.org/TR/css3-multicol/#column-breaks
- http://docs.webplatform.org/wiki/css/properties/break-after
- http://docs.webplatform.org/wiki/css/properties/break-inside
- http://docs.webplatform.org/wiki/css/properties/break-before
- http://trentwalton.com/2012/02/13/css-column-breaks/
