### PR TITLE
fix spelling error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The structure of this repo is:
 * **.gitignore** – is a list of files that git will ignore. I know you know that, but it's convention. 
 * **.travis.yml** – Configuration file for Travis CI. Travis CI is a hosted continuous integration service for the open source community.
 * **Gruntfle.js** – task runner. If you don't want to use lesshat-devstack ignore it.
-* **LICENCE** – self-explanatory
+* **LICENSE** – self-explanatory
 * **README-template.md** – If you want to edit readme, edit it in this file. README.md is generated.
 * **README.md** – please don't edit this file. Either edit README-template.md or documentation inside mixins/<mixin-name> folder.
 * **Bower** – is like NPM for frontend. NPM is like Gems for JavaScript. I could go on forever…


### PR DESCRIPTION
Noticed that **LICENSE** was spelled incorrectly in the README.
