### PR TITLE
Correction of placeholder color for FF19+

### DIFF
--- a/mixins/placeholder/placeholder.less
+++ b/mixins/placeholder/placeholder.less
@@ -8,6 +8,7 @@
     }
     @{element}::-moz-placeholder {
        color: @color;
+       opacity: 1;
     }
     @{element}:-ms-input-placeholder {
        color: @color;
@@ -22,6 +23,7 @@
     }
     &::-moz-placeholder {
        color: @color;
+       opacity: 1;
     }
     &:-ms-input-placeholder {
        color: @color;


### PR DESCRIPTION
Firefox19+ set up opacity to 0.54 for placeholders. To avoid that and display right color, opacity has to be set up back to 1.
