### PR TITLE
Placing -ms before -o in the vendor prefix order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ README.md file is automatically generated.
 **[Documentation](#documentation) |**
 
 ---
-### Current version: v3.0.2 (2014-06-17)
+### Current version: v3.0.2 (2014-06-26)
 
 ## What's new?
 * Compiling LESS Hat is much more faster (up to 60× times). 
@@ -303,7 +303,7 @@ Default value: none
     div {
      -webkit-animation: nameAnimation 2s linear alternate;
      -moz-animation: nameAnimation 2s linear alternate;
-     -opera-animation: nameAnimation 2s linear alternate;
+     -o-animation: nameAnimation 2s linear alternate;
      animation: nameAnimation 2s linear alternate;
     }
 
@@ -342,7 +342,7 @@ If you omit units after time argument, `animation-delay` is trying to be smart a
     div {
      -webkit-animation-delay: 2s, 200ms;
      -moz-animation-delay: 2s, 200ms;
-     -opera-animation-delay: 2s, 200ms;
+     -o-animation-delay: 2s, 200ms;
      animation-delay: 2s, 200ms;
     }
 
@@ -371,7 +371,7 @@ Default value: normal
     div {
      -webkit-animation-direction: reverse, alternate;
      -moz-animation-direction: reverse, alternate;
-     -opera-animation-direction: reverse, alternate;
+     -o-animation-direction: reverse, alternate;
      animation-direction: reverse, alternate;
     }
 
@@ -410,7 +410,7 @@ If you omit units after time argument, `animation-duration` is trying to be smar
     div {
      -webkit-animation-duration: 2000ms;
      -moz-animation-duration: 2000ms;
-     -opera-animation-duration: 2000ms;
+     -o-animation-duration: 2000ms;
      animation-duration: 2000ms;
     }
   
@@ -439,7 +439,7 @@ Default value: none
     div {
      -webkit-animation-fill-mode: forwards;
      -moz-animation-fill-mode: forwards;
-     -opera-animation-fill-mode: forwards;
+     -o-animation-fill-mode: forwards;
      animation-fill-mode: forwards;
     }
 
@@ -468,7 +468,7 @@ Default value: 1
     div {
      -webkit-animation-iteration-count: 3;
      -moz-animation-iteration-count: 3;
-     -opera-animation-iteration-count: 3;
+     -o-animation-iteration-count: 3;
      animation-iteration-count: 3;
     } 
 
@@ -497,7 +497,7 @@ Default value: none
     div {
      -webkit-animation-name: animation-1, animation-2;
      -moz-animation-name: animation-1, animation-2;
-     -opera-animation-name: animation-1, animation-2;
+     -o-animation-name: animation-1, animation-2;
      animation-name: animation-1, animation-2;
     } 
 
@@ -526,7 +526,7 @@ Default value: running
     div {
      -webkit-animation-play-state: paused;
      -moz-animation-play-state: paused;
-     -opera-animation-play-state: paused;
+     -o-animation-play-state: paused;
      animation-play-state: paused;
     } 
 
@@ -555,7 +555,7 @@ Default value: ease
     div {
      -webkit-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
      -moz-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
-     -opera-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
+     -o-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
      animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
     } 
 
@@ -612,8 +612,8 @@ Default value: none
     div {
      -webkit-backface-visibility: none;
      -moz-backface-visibility: none;
-     -o-backface-visibility: none;
      -ms-backface-visibility: none;
+     -o-backface-visibility: none;
      backface-visibility: none;
     } 
 
@@ -875,7 +875,7 @@ Default value: based on individual properties
     div {
      -webkit-border-image: url(border.png) 61 45 62 54 repeat;
      -moz-border-image: url(border.png) 61 45 62 54 repeat;
-     -opera-border-image: url(border.png) 61 45 62 54 repeat;
+     -o-border-image: url(border.png) 61 45 62 54 repeat;
      border-image: url(border.png) 61 45 62 54 repeat;
     } 
 
@@ -2002,8 +2002,8 @@ Default value: 0
     div {
      -webkit-transform: rotate(45deg);
      -moz-transform: rotate(45deg);
-     -opera-transform: rotate(45deg);
      -ms-transform: rotate(45deg);
+     -o-transform: rotate(45deg);
      transform: rotate(45deg);
     }
 
@@ -2035,8 +2035,8 @@ Default value: 0, 0, 0, 0
     div {
      -webkit-transform: rotate3d(1, 0, 0, 50deg);
      -moz-transform: rotate3d(1, 0, 0, 50deg);
-     -opera-transform: rotate3d(1, 0, 0, 50deg);
      -ms-transform: rotate3d(1, 0, 0, 50deg);
+     -o-transform: rotate3d(1, 0, 0, 50deg);
      transform: rotate3d(1, 0, 0, 50deg);
     }
 
@@ -2069,8 +2069,8 @@ Default value: 0
     div {
      -webkit-transform: rotateX(45deg);
      -moz-transform: rotateX(45deg);
-     -opera-transform: rotateX(45deg);
      -ms-transform: rotateX(45deg);
+     -o-transform: rotateX(45deg);
      transform: rotateX(45deg);
     }
 
@@ -2102,8 +2102,8 @@ Default value: 0
     div {
      -webkit-transform: rotateY(45deg);
      -moz-transform: rotateY(45deg);
-     -opera-transform: rotateY(45deg);
      -ms-transform: rotateY(45deg);
+     -o-transform: rotateY(45deg);
      transform: rotateY(45deg);
     }
 
@@ -2135,8 +2135,8 @@ Default value: 0
     div {
      -webkit-transform: rotateZ(45deg);
      -moz-transform: rotateZ(45deg);
-     -opera-transform: rotateZ(45deg);
      -ms-transform: rotateZ(45deg);
+     -o-transform: rotateZ(45deg);
      transform: rotateZ(45deg);
     }
 
@@ -2198,8 +2198,8 @@ Default value: 1
     div {
      -webkit-transform: scale(2);
      -moz-transform: scale(2);
-     -opera-transform: scale(2);
      -ms-transform: scale(2);
+     -o-transform: scale(2);
      transform: scale(2);
     }
 
@@ -2227,8 +2227,8 @@ Default value: 1, 1, 1
     div {
      -webkit-transform: scale3d(1.5, 0.2, 3);
      -moz-transform: scale3d(1.5, 0.2, 3);
-     -opera-transform: scale3d(1.5, 0.2, 3);
      -ms-transform: scale3d(1.5, 0.2, 3);
+     -o-transform: scale3d(1.5, 0.2, 3);
      transform: scale3d(1.5, 0.2, 3);
     }
 
@@ -2257,8 +2257,8 @@ Default value: 1
     div {
      -webkit-transform: scaleX(1.5);
      -moz-transform: scaleX(1.5);
-     -opera-transform: scaleX(1.5);
      -ms-transform: scaleX(1.5);
+     -o-transform: scaleX(1.5);
      transform: scaleX(1.5);
     }
 
@@ -2286,8 +2286,8 @@ Default value: 1
     div {
      -webkit-transform: scaleY(1.5);
      -moz-transform: scaleY(1.5);
-     -opera-transform: scaleY(1.5);
      -ms-transform: scaleY(1.5);
+     -o-transform: scaleY(1.5);
      transform: scaleY(1.5);
     }
 
@@ -2315,8 +2315,8 @@ Default value: 1
     div {
      -webkit-transform: scaleZ(1.5);
      -moz-transform: scaleZ(1.5);
-     -opera-transform: scaleZ(1.5);
      -ms-transform: scaleZ(1.5);
+     -o-transform: scaleZ(1.5);
      transform: scaleZ(1.5);
     }
 
@@ -2443,8 +2443,8 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#sk
     div {
      -webkit-transform: skew(20deg, 30deg);
      -moz-transform: skew(20deg, 30deg);
-     -opera-transform: skew(20deg, 30deg);
      -ms-transform: skew(20deg, 30deg);
+     -o-transform: skew(20deg, 30deg);
      transform: skew(20deg, 30deg);
     }
 
@@ -2476,8 +2476,8 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#sk
     div {
      -webkit-transform: skewX(20deg);
      -moz-transform: skewX(20deg);
-     -opera-transform: skewX(20deg);
      -ms-transform: skewX(20deg);
+     -o-transform: skewX(20deg);
      transform: skewX(20deg);
     }
 
@@ -2509,8 +2509,8 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#sk
     div {
      -webkit-transform: skewY(20deg);
      -moz-transform: skewY(20deg);
-     -opera-transform: skewY(20deg);
      -ms-transform: skewY(20deg);
+     -o-transform: skewY(20deg);
      transform: skewY(20deg);
     }
 
@@ -2548,8 +2548,8 @@ Resources: **[WebPlatform](http://docs.webplatform.org/wiki/css/properties/trans
     div {
      -webkit-transform: scale(.5) translate(10, 20);
      -moz-transform: scale(.5) translate(10, 20);
-     -opera-transform: scale(.5) translate(10, 20);
      -ms-transform: scale(.5) translate(10, 20);
+     -o-transform: scale(.5) translate(10, 20);
      transform: scale(.5) translate(10, 20);
     }
 
@@ -2582,8 +2582,8 @@ Resources: **[WebPlatform](http://docs.webplatform.org/wiki/css/properties/trans
     div {
      -webkit-transform-origin: 50% 50%;
      -moz-transform-origin: 50% 50%;
-     -opera-transform-origin: 50% 50%;
      -ms-transform-origin: 50% 50%;
+     -o-transform-origin: 50% 50%;
      transform-origin: 50% 50%;
     }
 
@@ -2612,8 +2612,8 @@ Resources: **[WebPlatform](http://docs.webplatform.org/wiki/css/properties/trans
     div {
      -webkit-transform-style: preserve-3d;
      -moz-transform-style: preserve-3d;
-     -opera-transform-style: preserve-3d;
      -ms-transform-style: preserve-3d;
+     -o-transform-style: preserve-3d;
      transform-style: preserve-3d;
     }
 
@@ -2851,6 +2851,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translate(200px);
      -moz-transform: translate(200px);
+     -ms-transform: translate(200px);
      -o-transform: translate(200px);
      transform: translate(200px);
     }
@@ -2883,6 +2884,7 @@ Resources: **<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     div {
      -webkit-transform: translate3d(20px, 30px, 10px);
      -moz-transform: translate3d(20px, 30px, 10px);
+     -ms-transform: translate3d(20px, 30px, 10px);
      -o-transform: translate3d(20px, 30px, 10px);
      transform: translate3d(20px, 30px, 10px);
     }
@@ -2916,6 +2918,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translateX(20px);
      -moz-transform: translateX(20px);
+     -ms-transform: translateX(20px);
      -o-transform: translateX(20px);
      transform: translateX(20px);
     }
@@ -2948,6 +2951,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translateY(20px);
      -moz-transform: translateY(20px);
+     -ms-transform: translateY(20px);
      -o-transform: translateY(20px);
      transform: translateY(20px);
     }
@@ -2980,6 +2984,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translateZ(20px);
      -moz-transform: translateZ(20px);
+     -ms-transform: translateZ(20px);
      -o-transform: translateZ(20px);
      transform: translateZ(20px);
     }

--- a/build/lesshat-prefixed.less
+++ b/build/lesshat-prefixed.less
@@ -6,7 +6,7 @@
 // Handcrafted by Petr Brzek, lesshat.com
 // Works great with CSS Hat csshat.com
 
-// version: v3.0.2 (2014-06-17)
+// version: v3.0.2 (2014-06-26)
 
 // TABLE OF MIXINS:
 	// align-content
@@ -208,8 +208,8 @@
   @process: ~`(function(r){return r||"visible"})((function(){var r="@{arguments}";return r=r.replace(/^\[|\]$/g,"")})())`;
   -webkit-backface-visibility: @process;
   -moz-backface-visibility: @process;
-  -o-backface-visibility: @process;
   -ms-backface-visibility: @process;
+  -o-backface-visibility: @process;
   backface-visibility: @process;
 }
 
@@ -580,8 +580,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotate(@process);
   -moz-transform: rotate(@process);
-  -o-transform: rotate(@process);
   -ms-transform: rotate(@process);
+  -o-transform: rotate(@process);
   transform: rotate(@process);
 }
 
@@ -589,8 +589,8 @@
   @process: ~`(function(e){return e=e||"0, 0, 0, 0",e=e.replace(/,\s*\d+$/,function(e){return e+"deg"})})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotate3d(@process);
   -moz-transform: rotate3d(@process);
-  -o-transform: rotate3d(@process);
   -ms-transform: rotate3d(@process);
+  -o-transform: rotate3d(@process);
   transform: rotate3d(@process);
 }
 
@@ -598,8 +598,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotateX(@process);
   -moz-transform: rotateX(@process);
-  -o-transform: rotateX(@process);
   -ms-transform: rotateX(@process);
+  -o-transform: rotateX(@process);
   transform: rotateX(@process);
 }
 
@@ -607,8 +607,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotateY(@process);
   -moz-transform: rotateY(@process);
-  -o-transform: rotateY(@process);
   -ms-transform: rotateY(@process);
+  -o-transform: rotateY(@process);
   transform: rotateY(@process);
 }
 
@@ -616,8 +616,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotateZ(@process);
   -moz-transform: rotateZ(@process);
-  -o-transform: rotateZ(@process);
   -ms-transform: rotateZ(@process);
+  -o-transform: rotateZ(@process);
   transform: rotateZ(@process);
 }
 
@@ -633,8 +633,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scale(@process);
   -moz-transform: scale(@process);
-  -o-transform: scale(@process);
   -ms-transform: scale(@process);
+  -o-transform: scale(@process);
   transform: scale(@process);
 }
 
@@ -642,8 +642,8 @@
   @process: ~`(function(e){return e=e||"1, 1, 1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scale3d(@process);
   -moz-transform: scale3d(@process);
-  -o-transform: scale3d(@process);
   -ms-transform: scale3d(@process);
+  -o-transform: scale3d(@process);
   transform: scale3d(@process);
 }
 
@@ -651,8 +651,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scaleX(@process);
   -moz-transform: scaleX(@process);
-  -o-transform: scaleX(@process);
   -ms-transform: scaleX(@process);
+  -o-transform: scaleX(@process);
   transform: scaleX(@process);
 }
 
@@ -660,8 +660,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scaleY(@process);
   -moz-transform: scaleY(@process);
-  -o-transform: scaleY(@process);
   -ms-transform: scaleY(@process);
+  -o-transform: scaleY(@process);
   transform: scaleY(@process);
 }
 
@@ -669,8 +669,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scaleZ(@process);
   -moz-transform: scaleZ(@process);
-  -o-transform: scaleZ(@process);
   -ms-transform: scaleZ(@process);
+  -o-transform: scaleZ(@process);
   transform: scaleZ(@process);
 }
 
@@ -740,8 +740,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: skew(@process);
   -moz-transform: skew(@process);
-  -o-transform: skew(@process);
   -ms-transform: skew(@process);
+  -o-transform: skew(@process);
   transform: skew(@process);
 }
 
@@ -749,8 +749,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: skewX(@process);
   -moz-transform: skewX(@process);
-  -o-transform: skewX(@process);
   -ms-transform: skewX(@process);
+  -o-transform: skewX(@process);
   transform: skewX(@process);
 }
 
@@ -758,8 +758,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: skewY(@process);
   -moz-transform: skewY(@process);
-  -o-transform: skewY(@process);
   -ms-transform: skewY(@process);
+  -o-transform: skewY(@process);
   transform: skewY(@process);
 }
 
@@ -767,8 +767,8 @@
   @process: ~`(function(e){e=e||"none";var r={translate:"px",rotate:"deg",rotate3d:"deg",skew:"deg"};/^\w*\(?[a-z0-9.]*\)?/.test(e)&&(e=e.replace(/(?:,)(?![^(]*\))/g,""));for(var t in r)e.indexOf(t)>=0&&(e=e.replace(new RegExp(t+"[\\w]?\\([a-z0-9, %]*\\)"),function(e){var n=/(\d+\.?\d*)(?!\w|%)/g;return"rotate3d"==t&&(n=/,\s*\d+$/),e.replace(n,function(e){return e+r[t]})}));return e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: @process;
   -moz-transform: @process;
-  -o-transform: @process;
   -ms-transform: @process;
+  -o-transform: @process;
   transform: @process;
 }
 
@@ -776,8 +776,8 @@
   @process: ~`(function(e){e=e||"50% 50% 0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return/^[^, ]*,/.test(e)&&(e=e.replace(/(?:,)(?![^(]*\))/g,"")),r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"%"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform-origin: @process;
   -moz-transform-origin: @process;
-  -o-transform-origin: @process;
   -ms-transform-origin: @process;
+  -o-transform-origin: @process;
   transform-origin: @process;
 }
 
@@ -785,8 +785,8 @@
   @process: ~`(function(e){return e=e||"flat"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform-style: @process;
   -moz-transform-style: @process;
-  -o-transform-style: @process;
   -ms-transform-style: @process;
+  -o-transform-style: @process;
   transform-style: @process;
 }
 
@@ -840,8 +840,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translate(@process);
   -moz-transform: translate(@process);
-  -o-transform: translate(@process);
   -ms-transform: translate(@process);
+  -o-transform: translate(@process);
   transform: translate(@process);
 }
 
@@ -849,8 +849,8 @@
   @process: ~`(function(e){e=e||"0, 0, 0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translate3d(@process);
   -moz-transform: translate3d(@process);
-  -o-transform: translate3d(@process);
   -ms-transform: translate3d(@process);
+  -o-transform: translate3d(@process);
   transform: translate3d(@process);
 }
 
@@ -858,8 +858,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translateX(@process);
   -moz-transform: translateX(@process);
-  -o-transform: translateX(@process);
   -ms-transform: translateX(@process);
+  -o-transform: translateX(@process);
   transform: translateX(@process);
 }
 
@@ -867,8 +867,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translateY(@process);
   -moz-transform: translateY(@process);
-  -o-transform: translateY(@process);
   -ms-transform: translateY(@process);
+  -o-transform: translateY(@process);
   transform: translateY(@process);
 }
 
@@ -876,8 +876,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translateZ(@process);
   -moz-transform: translateZ(@process);
-  -o-transform: translateZ(@process);
   -ms-transform: translateZ(@process);
+  -o-transform: translateZ(@process);
   transform: translateZ(@process);
 }
 

--- a/build/lesshat.less
+++ b/build/lesshat.less
@@ -6,7 +6,7 @@
 // Handcrafted by Petr Brzek, lesshat.com
 // Works great with CSS Hat csshat.com
 
-// version: v3.0.2 (2014-06-17)
+// version: v3.0.2 (2014-06-26)
 
 // TABLE OF MIXINS:
 	// align-content
@@ -208,8 +208,8 @@
   @process: ~`(function(r){return r||"visible"})((function(){var r="@{arguments}";return r=r.replace(/^\[|\]$/g,"")})())`;
   -webkit-backface-visibility: @process;
   -moz-backface-visibility: @process;
-  -o-backface-visibility: @process;
   -ms-backface-visibility: @process;
+  -o-backface-visibility: @process;
   backface-visibility: @process;
 }
 
@@ -580,8 +580,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotate(@process);
   -moz-transform: rotate(@process);
-  -o-transform: rotate(@process);
   -ms-transform: rotate(@process);
+  -o-transform: rotate(@process);
   transform: rotate(@process);
 }
 
@@ -589,8 +589,8 @@
   @process: ~`(function(e){return e=e||"0, 0, 0, 0",e=e.replace(/,\s*\d+$/,function(e){return e+"deg"})})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotate3d(@process);
   -moz-transform: rotate3d(@process);
-  -o-transform: rotate3d(@process);
   -ms-transform: rotate3d(@process);
+  -o-transform: rotate3d(@process);
   transform: rotate3d(@process);
 }
 
@@ -598,8 +598,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotateX(@process);
   -moz-transform: rotateX(@process);
-  -o-transform: rotateX(@process);
   -ms-transform: rotateX(@process);
+  -o-transform: rotateX(@process);
   transform: rotateX(@process);
 }
 
@@ -607,8 +607,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotateY(@process);
   -moz-transform: rotateY(@process);
-  -o-transform: rotateY(@process);
   -ms-transform: rotateY(@process);
+  -o-transform: rotateY(@process);
   transform: rotateY(@process);
 }
 
@@ -616,8 +616,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: rotateZ(@process);
   -moz-transform: rotateZ(@process);
-  -o-transform: rotateZ(@process);
   -ms-transform: rotateZ(@process);
+  -o-transform: rotateZ(@process);
   transform: rotateZ(@process);
 }
 
@@ -633,8 +633,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scale(@process);
   -moz-transform: scale(@process);
-  -o-transform: scale(@process);
   -ms-transform: scale(@process);
+  -o-transform: scale(@process);
   transform: scale(@process);
 }
 
@@ -642,8 +642,8 @@
   @process: ~`(function(e){return e=e||"1, 1, 1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scale3d(@process);
   -moz-transform: scale3d(@process);
-  -o-transform: scale3d(@process);
   -ms-transform: scale3d(@process);
+  -o-transform: scale3d(@process);
   transform: scale3d(@process);
 }
 
@@ -651,8 +651,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scaleX(@process);
   -moz-transform: scaleX(@process);
-  -o-transform: scaleX(@process);
   -ms-transform: scaleX(@process);
+  -o-transform: scaleX(@process);
   transform: scaleX(@process);
 }
 
@@ -660,8 +660,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scaleY(@process);
   -moz-transform: scaleY(@process);
-  -o-transform: scaleY(@process);
   -ms-transform: scaleY(@process);
+  -o-transform: scaleY(@process);
   transform: scaleY(@process);
 }
 
@@ -669,8 +669,8 @@
   @process: ~`(function(e){return e=e||"1"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: scaleZ(@process);
   -moz-transform: scaleZ(@process);
-  -o-transform: scaleZ(@process);
   -ms-transform: scaleZ(@process);
+  -o-transform: scaleZ(@process);
   transform: scaleZ(@process);
 }
 
@@ -740,8 +740,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: skew(@process);
   -moz-transform: skew(@process);
-  -o-transform: skew(@process);
   -ms-transform: skew(@process);
+  -o-transform: skew(@process);
   transform: skew(@process);
 }
 
@@ -749,8 +749,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: skewX(@process);
   -moz-transform: skewX(@process);
-  -o-transform: skewX(@process);
   -ms-transform: skewX(@process);
+  -o-transform: skewX(@process);
   transform: skewX(@process);
 }
 
@@ -758,8 +758,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"deg"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: skewY(@process);
   -moz-transform: skewY(@process);
-  -o-transform: skewY(@process);
   -ms-transform: skewY(@process);
+  -o-transform: skewY(@process);
   transform: skewY(@process);
 }
 
@@ -767,8 +767,8 @@
   @process: ~`(function(e){e=e||"none";var r={translate:"px",rotate:"deg",rotate3d:"deg",skew:"deg"};/^\w*\(?[a-z0-9.]*\)?/.test(e)&&(e=e.replace(/(?:,)(?![^(]*\))/g,""));for(var t in r)e.indexOf(t)>=0&&(e=e.replace(new RegExp(t+"[\\w]?\\([a-z0-9, %]*\\)"),function(e){var n=/(\d+\.?\d*)(?!\w|%)/g;return"rotate3d"==t&&(n=/,\s*\d+$/),e.replace(n,function(e){return e+r[t]})}));return e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: @process;
   -moz-transform: @process;
-  -o-transform: @process;
   -ms-transform: @process;
+  -o-transform: @process;
   transform: @process;
 }
 
@@ -776,8 +776,8 @@
   @process: ~`(function(e){e=e||"50% 50% 0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return/^[^, ]*,/.test(e)&&(e=e.replace(/(?:,)(?![^(]*\))/g,"")),r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"%"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform-origin: @process;
   -moz-transform-origin: @process;
-  -o-transform-origin: @process;
   -ms-transform-origin: @process;
+  -o-transform-origin: @process;
   transform-origin: @process;
 }
 
@@ -785,8 +785,8 @@
   @process: ~`(function(e){return e=e||"flat"})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform-style: @process;
   -moz-transform-style: @process;
-  -o-transform-style: @process;
   -ms-transform-style: @process;
+  -o-transform-style: @process;
   transform-style: @process;
 }
 
@@ -840,8 +840,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translate(@process);
   -moz-transform: translate(@process);
-  -o-transform: translate(@process);
   -ms-transform: translate(@process);
+  -o-transform: translate(@process);
   transform: translate(@process);
 }
 
@@ -849,8 +849,8 @@
   @process: ~`(function(e){e=e||"0, 0, 0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translate3d(@process);
   -moz-transform: translate3d(@process);
-  -o-transform: translate3d(@process);
   -ms-transform: translate3d(@process);
+  -o-transform: translate3d(@process);
   transform: translate3d(@process);
 }
 
@@ -858,8 +858,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translateX(@process);
   -moz-transform: translateX(@process);
-  -o-transform: translateX(@process);
   -ms-transform: translateX(@process);
+  -o-transform: translateX(@process);
   transform: translateX(@process);
 }
 
@@ -867,8 +867,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translateY(@process);
   -moz-transform: translateY(@process);
-  -o-transform: translateY(@process);
   -ms-transform: translateY(@process);
+  -o-transform: translateY(@process);
   transform: translateY(@process);
 }
 
@@ -876,8 +876,8 @@
   @process: ~`(function(e){e=e||"0";var r=/\d/gi,t=/(?:\s|^)(\.?\d+\.?\d*)(?![^(]*\)|\w|%|\.)/gi;return r.test(e)&&(e=e.replace(t,function(e){return 0==e&&e||e+"px"})),e})((function(){var e="@{arguments}";return e=e.replace(/^\[|\]$/g,"")})())`;
   -webkit-transform: translateZ(@process);
   -moz-transform: translateZ(@process);
-  -o-transform: translateZ(@process);
   -ms-transform: translateZ(@process);
+  -o-transform: translateZ(@process);
   transform: translateZ(@process);
 }
 

--- a/mixins/animation-delay/animation-delay.md
+++ b/mixins/animation-delay/animation-delay.md
@@ -31,7 +31,7 @@ If you omit units after time argument, `animation-delay` is trying to be smart a
     div {
      -webkit-animation-delay: 2s, 200ms;
      -moz-animation-delay: 2s, 200ms;
-     -opera-animation-delay: 2s, 200ms;
+     -o-animation-delay: 2s, 200ms;
      animation-delay: 2s, 200ms;
     }
 

--- a/mixins/animation-direction/animation-direction.md
+++ b/mixins/animation-direction/animation-direction.md
@@ -21,7 +21,7 @@ Default value: normal
     div {
      -webkit-animation-direction: reverse, alternate;
      -moz-animation-direction: reverse, alternate;
-     -opera-animation-direction: reverse, alternate;
+     -o-animation-direction: reverse, alternate;
      animation-direction: reverse, alternate;
     }
 

--- a/mixins/animation-duration/animation-duration.md
+++ b/mixins/animation-duration/animation-duration.md
@@ -31,7 +31,7 @@ If you omit units after time argument, `animation-duration` is trying to be smar
     div {
      -webkit-animation-duration: 2000ms;
      -moz-animation-duration: 2000ms;
-     -opera-animation-duration: 2000ms;
+     -o-animation-duration: 2000ms;
      animation-duration: 2000ms;
     }
   

--- a/mixins/animation-fill-mode/animation-fill-mode.md
+++ b/mixins/animation-fill-mode/animation-fill-mode.md
@@ -21,7 +21,7 @@ Default value: none
     div {
      -webkit-animation-fill-mode: forwards;
      -moz-animation-fill-mode: forwards;
-     -opera-animation-fill-mode: forwards;
+     -o-animation-fill-mode: forwards;
      animation-fill-mode: forwards;
     }
 

--- a/mixins/animation-iteration-count/animation-iteration-count.md
+++ b/mixins/animation-iteration-count/animation-iteration-count.md
@@ -21,7 +21,7 @@ Default value: 1
     div {
      -webkit-animation-iteration-count: 3;
      -moz-animation-iteration-count: 3;
-     -opera-animation-iteration-count: 3;
+     -o-animation-iteration-count: 3;
      animation-iteration-count: 3;
     } 
 

--- a/mixins/animation-name/animation-name.md
+++ b/mixins/animation-name/animation-name.md
@@ -21,7 +21,7 @@ Default value: none
     div {
      -webkit-animation-name: animation-1, animation-2;
      -moz-animation-name: animation-1, animation-2;
-     -opera-animation-name: animation-1, animation-2;
+     -o-animation-name: animation-1, animation-2;
      animation-name: animation-1, animation-2;
     } 
 

--- a/mixins/animation-play-state/animation-play-state.md
+++ b/mixins/animation-play-state/animation-play-state.md
@@ -21,7 +21,7 @@ Default value: running
     div {
      -webkit-animation-play-state: paused;
      -moz-animation-play-state: paused;
-     -opera-animation-play-state: paused;
+     -o-animation-play-state: paused;
      animation-play-state: paused;
     } 
 

--- a/mixins/animation-timing-function/animation-timing-function.md
+++ b/mixins/animation-timing-function/animation-timing-function.md
@@ -21,7 +21,7 @@ Default value: ease
     div {
      -webkit-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
      -moz-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
-     -opera-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
+     -o-animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
      animation-timing-function: cubic-bezier(0.1, 0.7, 1.0, 0.1);
     } 
 

--- a/mixins/animation/animation.md
+++ b/mixins/animation/animation.md
@@ -21,7 +21,7 @@ Default value: none
     div {
      -webkit-animation: nameAnimation 2s linear alternate;
      -moz-animation: nameAnimation 2s linear alternate;
-     -opera-animation: nameAnimation 2s linear alternate;
+     -o-animation: nameAnimation 2s linear alternate;
      animation: nameAnimation 2s linear alternate;
     }
 

--- a/mixins/backface-visibility/backface-visibility.js
+++ b/mixins/backface-visibility/backface-visibility.js
@@ -10,7 +10,7 @@ var backfaceVisibility = function backfaceVisibility(value) {
  * For which browsers is this mixin specified
  */
 
-backfaceVisibility.vendors = ['webkit', 'moz', 'opera', 'ms'];
+backfaceVisibility.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/backface-visibility/backface-visibility.md
+++ b/mixins/backface-visibility/backface-visibility.md
@@ -21,8 +21,8 @@ Default value: none
     div {
      -webkit-backface-visibility: none;
      -moz-backface-visibility: none;
-     -o-backface-visibility: none;
      -ms-backface-visibility: none;
+     -o-backface-visibility: none;
      backface-visibility: none;
     } 
 

--- a/mixins/border-image/border-image.md
+++ b/mixins/border-image/border-image.md
@@ -26,7 +26,7 @@ Default value: based on individual properties
     div {
      -webkit-border-image: url(border.png) 61 45 62 54 repeat;
      -moz-border-image: url(border.png) 61 45 62 54 repeat;
-     -opera-border-image: url(border.png) 61 45 62 54 repeat;
+     -o-border-image: url(border.png) 61 45 62 54 repeat;
      border-image: url(border.png) 61 45 62 54 repeat;
     } 
 

--- a/mixins/rotate/rotate.js
+++ b/mixins/rotate/rotate.js
@@ -29,7 +29,7 @@ rotate.result = {
  * For which browsers is this mixin specified
  */
 
-rotate.vendors = ['webkit', 'moz', 'opera', 'ms'];
+rotate.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/rotate/rotate.md
+++ b/mixins/rotate/rotate.md
@@ -25,8 +25,8 @@ Default value: 0
     div {
      -webkit-transform: rotate(45deg);
      -moz-transform: rotate(45deg);
-     -opera-transform: rotate(45deg);
      -ms-transform: rotate(45deg);
+     -o-transform: rotate(45deg);
      transform: rotate(45deg);
     }
 

--- a/mixins/rotate3d/rotate3d.js
+++ b/mixins/rotate3d/rotate3d.js
@@ -24,7 +24,7 @@ rotate3d.result = {
  * For which browsers is this mixin specified
  */
 
-rotate3d.vendors = ['webkit', 'moz', 'opera', 'ms'];
+rotate3d.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/rotate3d/rotate3d.md
+++ b/mixins/rotate3d/rotate3d.md
@@ -25,8 +25,8 @@ Default value: 0, 0, 0, 0
     div {
      -webkit-transform: rotate3d(1, 0, 0, 50deg);
      -moz-transform: rotate3d(1, 0, 0, 50deg);
-     -opera-transform: rotate3d(1, 0, 0, 50deg);
      -ms-transform: rotate3d(1, 0, 0, 50deg);
+     -o-transform: rotate3d(1, 0, 0, 50deg);
      transform: rotate3d(1, 0, 0, 50deg);
     }
 

--- a/mixins/rotateX/rotateX.js
+++ b/mixins/rotateX/rotateX.js
@@ -29,7 +29,7 @@ rotateX.result = {
  * For which browsers is this mixin specified
  */
 
-rotateX.vendors = ['webkit', 'moz', 'opera', 'ms'];
+rotateX.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/rotateX/rotateX.md
+++ b/mixins/rotateX/rotateX.md
@@ -25,8 +25,8 @@ Default value: 0
     div {
      -webkit-transform: rotateX(45deg);
      -moz-transform: rotateX(45deg);
-     -opera-transform: rotateX(45deg);
      -ms-transform: rotateX(45deg);
+     -o-transform: rotateX(45deg);
      transform: rotateX(45deg);
     }
 

--- a/mixins/rotateY/rotateY.js
+++ b/mixins/rotateY/rotateY.js
@@ -29,7 +29,7 @@ rotateY.result = {
  * For which browsers is this mixin specified
  */
 
-rotateY.vendors = ['webkit', 'moz', 'opera', 'ms'];
+rotateY.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/rotateY/rotateY.md
+++ b/mixins/rotateY/rotateY.md
@@ -25,8 +25,8 @@ Default value: 0
     div {
      -webkit-transform: rotateY(45deg);
      -moz-transform: rotateY(45deg);
-     -opera-transform: rotateY(45deg);
      -ms-transform: rotateY(45deg);
+     -o-transform: rotateY(45deg);
      transform: rotateY(45deg);
     }
 

--- a/mixins/rotateZ/rotateZ.js
+++ b/mixins/rotateZ/rotateZ.js
@@ -29,7 +29,7 @@ rotateZ.result = {
  * For which browsers is this mixin specified
  */
 
-rotateZ.vendors = ['webkit', 'moz', 'opera', 'ms'];
+rotateZ.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/rotateZ/rotateZ.md
+++ b/mixins/rotateZ/rotateZ.md
@@ -25,8 +25,8 @@ Default value: 0
     div {
      -webkit-transform: rotateZ(45deg);
      -moz-transform: rotateZ(45deg);
-     -opera-transform: rotateZ(45deg);
      -ms-transform: rotateZ(45deg);
+     -o-transform: rotateZ(45deg);
      transform: rotateZ(45deg);
     }
 

--- a/mixins/scale/scale.js
+++ b/mixins/scale/scale.js
@@ -21,7 +21,7 @@ scale.result = {
  * For which browsers is this mixin specified
  */
 
-scale.vendors = ['webkit', 'moz', 'opera', 'ms'];
+scale.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/scale/scale.md
+++ b/mixins/scale/scale.md
@@ -21,8 +21,8 @@ Default value: 1
     div {
      -webkit-transform: scale(2);
      -moz-transform: scale(2);
-     -opera-transform: scale(2);
      -ms-transform: scale(2);
+     -o-transform: scale(2);
      transform: scale(2);
     }
 

--- a/mixins/scale3d/scale3d.js
+++ b/mixins/scale3d/scale3d.js
@@ -21,7 +21,7 @@ scale3d.result = {
  * For which browsers is this mixin specified
  */
 
-scale3d.vendors = ['webkit', 'moz', 'opera', 'ms'];
+scale3d.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/scale3d/scale3d.md
+++ b/mixins/scale3d/scale3d.md
@@ -21,8 +21,8 @@ Default value: 1, 1, 1
     div {
      -webkit-transform: scale3d(1.5, 0.2, 3);
      -moz-transform: scale3d(1.5, 0.2, 3);
-     -opera-transform: scale3d(1.5, 0.2, 3);
      -ms-transform: scale3d(1.5, 0.2, 3);
+     -o-transform: scale3d(1.5, 0.2, 3);
      transform: scale3d(1.5, 0.2, 3);
     }
 

--- a/mixins/scaleX/scaleX.js
+++ b/mixins/scaleX/scaleX.js
@@ -21,7 +21,7 @@ scaleX.result = {
  * For which browsers is this mixin specified
  */
 
-scaleX.vendors = ['webkit', 'moz', 'opera', 'ms'];
+scaleX.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/scaleX/scaleX.md
+++ b/mixins/scaleX/scaleX.md
@@ -21,8 +21,8 @@ Default value: 1
     div {
      -webkit-transform: scaleX(1.5);
      -moz-transform: scaleX(1.5);
-     -opera-transform: scaleX(1.5);
      -ms-transform: scaleX(1.5);
+     -o-transform: scaleX(1.5);
      transform: scaleX(1.5);
     }
 

--- a/mixins/scaleY/scaleY.js
+++ b/mixins/scaleY/scaleY.js
@@ -21,7 +21,7 @@ scaleY.result = {
  * For which browsers is this mixin specified
  */
 
-scaleY.vendors = ['webkit', 'moz', 'opera', 'ms'];
+scaleY.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/scaleY/scaleY.md
+++ b/mixins/scaleY/scaleY.md
@@ -21,8 +21,8 @@ Default value: 1
     div {
      -webkit-transform: scaleY(1.5);
      -moz-transform: scaleY(1.5);
-     -opera-transform: scaleY(1.5);
      -ms-transform: scaleY(1.5);
+     -o-transform: scaleY(1.5);
      transform: scaleY(1.5);
     }
 

--- a/mixins/scaleZ/scaleZ.js
+++ b/mixins/scaleZ/scaleZ.js
@@ -21,7 +21,7 @@ scaleZ.result = {
  * For which browsers is this mixin specified
  */
 
-scaleZ.vendors = ['webkit', 'moz', 'opera', 'ms'];
+scaleZ.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/scaleZ/scaleZ.md
+++ b/mixins/scaleZ/scaleZ.md
@@ -21,8 +21,8 @@ Default value: 1
     div {
      -webkit-transform: scaleZ(1.5);
      -moz-transform: scaleZ(1.5);
-     -opera-transform: scaleZ(1.5);
      -ms-transform: scaleZ(1.5);
+     -o-transform: scaleZ(1.5);
      transform: scaleZ(1.5);
     }
 

--- a/mixins/skew/skew.js
+++ b/mixins/skew/skew.js
@@ -29,7 +29,7 @@ skew.result = {
  * For which browsers is this mixin specified
  */
 
-skew.vendors = ['webkit', 'moz', 'opera', 'ms'];
+skew.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/skew/skew.md
+++ b/mixins/skew/skew.md
@@ -25,8 +25,8 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#sk
     div {
      -webkit-transform: skew(20deg, 30deg);
      -moz-transform: skew(20deg, 30deg);
-     -opera-transform: skew(20deg, 30deg);
      -ms-transform: skew(20deg, 30deg);
+     -o-transform: skew(20deg, 30deg);
      transform: skew(20deg, 30deg);
     }
 

--- a/mixins/skewX/skewX.js
+++ b/mixins/skewX/skewX.js
@@ -29,7 +29,7 @@ skewX.result = {
  * For which browsers is this mixin specified
  */
 
-skewX.vendors = ['webkit', 'moz', 'opera', 'ms'];
+skewX.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/skewX/skewX.md
+++ b/mixins/skewX/skewX.md
@@ -25,8 +25,8 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#sk
     div {
      -webkit-transform: skewX(20deg);
      -moz-transform: skewX(20deg);
-     -opera-transform: skewX(20deg);
      -ms-transform: skewX(20deg);
+     -o-transform: skewX(20deg);
      transform: skewX(20deg);
     }
 

--- a/mixins/skewY/skewY.js
+++ b/mixins/skewY/skewY.js
@@ -29,7 +29,7 @@ skewY.result = {
  * For which browsers is this mixin specified
  */
 
-skewY.vendors = ['webkit', 'moz', 'opera', 'ms'];
+skewY.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/skewY/skewY.md
+++ b/mixins/skewY/skewY.md
@@ -25,8 +25,8 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#sk
     div {
      -webkit-transform: skewY(20deg);
      -moz-transform: skewY(20deg);
-     -opera-transform: skewY(20deg);
      -ms-transform: skewY(20deg);
+     -o-transform: skewY(20deg);
      transform: skewY(20deg);
     }
 

--- a/mixins/transform-origin/transform-origin.js
+++ b/mixins/transform-origin/transform-origin.js
@@ -24,7 +24,7 @@ var transformOrigin = function transformOrigin(value) {
  * For which browsers is this mixin specified
  */
 
-transformOrigin.vendors = ['webkit', 'moz', 'opera', 'ms'];
+transformOrigin.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 
 /**

--- a/mixins/transform-origin/transform-origin.md
+++ b/mixins/transform-origin/transform-origin.md
@@ -25,8 +25,8 @@ Resources: **[WebPlatform](http://docs.webplatform.org/wiki/css/properties/trans
     div {
      -webkit-transform-origin: 50% 50%;
      -moz-transform-origin: 50% 50%;
-     -opera-transform-origin: 50% 50%;
      -ms-transform-origin: 50% 50%;
+     -o-transform-origin: 50% 50%;
      transform-origin: 50% 50%;
     }
 

--- a/mixins/transform-style/transform-style.js
+++ b/mixins/transform-style/transform-style.js
@@ -12,7 +12,7 @@ var transformStyle = function transformStyle(value) {
  * For which browsers is this mixin specified
  */
 
-transformStyle.vendors = ['webkit', 'moz', 'opera', 'ms'];
+transformStyle.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 
 /**

--- a/mixins/transform-style/transform-style.md
+++ b/mixins/transform-style/transform-style.md
@@ -21,8 +21,8 @@ Resources: **[WebPlatform](http://docs.webplatform.org/wiki/css/properties/trans
     div {
      -webkit-transform-style: preserve-3d;
      -moz-transform-style: preserve-3d;
-     -opera-transform-style: preserve-3d;
      -ms-transform-style: preserve-3d;
+     -o-transform-style: preserve-3d;
      transform-style: preserve-3d;
     }
 

--- a/mixins/transform/transform.js
+++ b/mixins/transform/transform.js
@@ -37,7 +37,7 @@ var transform = function transform(value) {
  * For which browsers is this mixin specified
  */
 
-transform.vendors = ['webkit', 'moz', 'opera', 'ms'];
+transform.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 
 /**

--- a/mixins/transform/transform.md
+++ b/mixins/transform/transform.md
@@ -30,8 +30,8 @@ Resources: **[WebPlatform](http://docs.webplatform.org/wiki/css/properties/trans
     div {
      -webkit-transform: scale(.5) translate(10, 20);
      -moz-transform: scale(.5) translate(10, 20);
-     -opera-transform: scale(.5) translate(10, 20);
      -ms-transform: scale(.5) translate(10, 20);
+     -o-transform: scale(.5) translate(10, 20);
      transform: scale(.5) translate(10, 20);
     }
 

--- a/mixins/translate/translate.js
+++ b/mixins/translate/translate.js
@@ -29,7 +29,7 @@ translate.result = {
  * For which browsers is this mixin specified
  */
 
-translate.vendors = ['webkit', 'moz', 'opera', 'ms'];
+translate.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/translate/translate.md
+++ b/mixins/translate/translate.md
@@ -25,6 +25,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translate(200px);
      -moz-transform: translate(200px);
+     -ms-transform: translate(200px);
      -o-transform: translate(200px);
      transform: translate(200px);
     }

--- a/mixins/translate3d/translate3d.js
+++ b/mixins/translate3d/translate3d.js
@@ -29,7 +29,7 @@ translate3d.result = {
  * For which browsers is this mixin specified
  */
 
-translate3d.vendors = ['webkit', 'moz', 'opera', 'ms'];
+translate3d.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/translate3d/translate3d.md
+++ b/mixins/translate3d/translate3d.md
@@ -25,6 +25,7 @@ Resources: **<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     div {
      -webkit-transform: translate3d(20px, 30px, 10px);
      -moz-transform: translate3d(20px, 30px, 10px);
+     -ms-transform: translate3d(20px, 30px, 10px);
      -o-transform: translate3d(20px, 30px, 10px);
      transform: translate3d(20px, 30px, 10px);
     }

--- a/mixins/translateX/translateX.js
+++ b/mixins/translateX/translateX.js
@@ -29,7 +29,7 @@ translateX.result = {
  * For which browsers is this mixin specified
  */
 
-translateX.vendors = ['webkit', 'moz', 'opera', 'ms'];
+translateX.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/translateX/translateX.md
+++ b/mixins/translateX/translateX.md
@@ -25,6 +25,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translateX(20px);
      -moz-transform: translateX(20px);
+     -ms-transform: translateX(20px);
      -o-transform: translateX(20px);
      transform: translateX(20px);
     }

--- a/mixins/translateY/translateY.js
+++ b/mixins/translateY/translateY.js
@@ -29,7 +29,7 @@ translateY.result = {
  * For which browsers is this mixin specified
  */
 
-translateY.vendors = ['webkit', 'moz', 'opera', 'ms'];
+translateY.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/translateY/translateY.md
+++ b/mixins/translateY/translateY.md
@@ -25,6 +25,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translateY(20px);
      -moz-transform: translateY(20px);
+     -ms-transform: translateY(20px);
      -o-transform: translateY(20px);
      transform: translateY(20px);
     }

--- a/mixins/translateZ/translateZ.js
+++ b/mixins/translateZ/translateZ.js
@@ -29,7 +29,7 @@ translateZ.result = {
  * For which browsers is this mixin specified
  */
 
-translateZ.vendors = ['webkit', 'moz', 'opera', 'ms'];
+translateZ.vendors = ['webkit', 'moz', 'ms', 'opera'];
 
 /**
  * Export mixin

--- a/mixins/translateZ/translateZ.md
+++ b/mixins/translateZ/translateZ.md
@@ -25,6 +25,7 @@ Resources: **[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#tr
     div {
      -webkit-transform: translateZ(20px);
      -moz-transform: translateZ(20px);
+     -ms-transform: translateZ(20px);
      -o-transform: translateZ(20px);
      transform: translateZ(20px);
     }


### PR DESCRIPTION
Typically, `-ms` goes before `-o` when you're listing out a bunch of vendor prefixes. CSS linters (like RECESS) will throw an error if this order is incorrect. [See RECESS' prefix order.](https://github.com/twitter/recess/blob/master/lib/lint/strict-property-order.js#L20)
