### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1312,6 +1312,7 @@ Resources: **[CSS-Tricks](http://css-tricks.com/snippets/css/a-guide-to-flexbox/
      display: -ms-flexbox;
      display: -webkit-flex;
      display: -moz-box;
+     display: flex;
     } 
 
 


### PR DESCRIPTION
default syntax was missing in the compiled result of the `.display()` mixin
