### PR TITLE
Add less entry for Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
   },
   "scripts": {
     "test": "grunt test"
-  }
+  },
+  "less": "build/lesshat.less"
 }


### PR DESCRIPTION
When using [Webpack](http://webpack.github.io/) with lesshat, it needs to know which **less** file is the entry file. 

Just like bootstrap

```
"less": "less/bootstrap.less",
```