### PR TITLE
Fixes #156 #129 #139 by not only removing the extra semicolon, which …

### DIFF
--- a/mixins/keyframes/keyframes.js
+++ b/mixins/keyframes/keyframes.js
@@ -142,7 +142,7 @@ var keyframes = function keyframes(value) {
     }
 
   }
-
+  value = value + "}\n.lh-dummy { -lh-property:0";
   return value;
 };
 

--- a/mixins/keyframes/result.less
+++ b/mixins/keyframes/result.less
@@ -1,3 +1,1 @@
   @state: 1; lesshat-selector { -lh-property: @process; }
-
-


### PR DESCRIPTION
…is not the issue, but by adding the missing "}" on the same line at the last @*keyframe, or else the browsers will break. Currently OSX 10.11 and iOS9 beta do break. To close the "}", a dummy line must be added below, to reopen the "{" so then less can finally close it again.
